### PR TITLE
Add new observables for displayed and dismissed states

### DIFF
--- a/Sources/RxViewController/UIViewController+Rx.swift
+++ b/Sources/RxViewController/UIViewController+Rx.swift
@@ -50,5 +50,20 @@ public extension Reactive where Base: UIViewController {
     let source = self.methodInvoked(#selector(Base.didReceiveMemoryWarning)).map { _ in }
     return ControlEvent(events: source)
   }
+
+    /// Rx observable, triggered when the ViewController appearance state changes (true if the View is being displayed, false otherwise)
+    public var isVisible: Observable<Bool> {
+        let viewDidAppearObservable = self.base.rx.viewDidAppear.map { _ in true }
+        let viewWillDisappearObservable = self.base.rx.viewWillDisappear.map { _ in false }
+        return Observable<Bool>.merge(viewDidAppearObservable, viewWillDisappearObservable)
+    }
+
+    /// Rx observable, triggered when the ViewController is being dismissed
+    public var isDismissing: ControlEvent<Bool> {
+        let source = self.sentMessage(#selector(Base.dismiss)).map { $0.first as? Bool ?? false }
+        return ControlEvent(events: source)
+    }
+
 }
 #endif
+

--- a/Tests/RxViewControllerTests/UIViewControllerTests.swift
+++ b/Tests/RxViewControllerTests/UIViewControllerTests.swift
@@ -118,6 +118,30 @@ final class UIViewControllerTests: XCTestCase {
       XCTAssertEqual(events.at(100...).filter(.next).count, 1)
     }
   }
+
+    func testIsVisible() {
+        let test = RxExpect()
+        let viewController = UIViewController()
+        test.scheduler.scheduleAt(100) { viewController.viewDidAppear(false) }
+        test.scheduler.scheduleAt(200) { viewController.viewWillDisappear(false) }
+        test.assert(viewController.rx.isVisible) { events in
+            XCTAssertEqual(events.at(..<100).filter(.next).count, 0)
+            XCTAssertEqual(events.at(100...).filter(.next).first?.value.element ?? false, true)
+            XCTAssertEqual(events.at(200...).filter(.next).first?.value.element ?? true, false)
+        }
+    }
+
+    func testIsDismissing() {
+        let test = RxExpect()
+        let viewController = UIViewController()
+        test.scheduler.scheduleAt(100) { viewController.viewDidAppear(false) }
+        test.scheduler.scheduleAt(200) { viewController.dismiss(animated: false) }
+        test.assert(viewController.rx.isDismissing) { events in
+            XCTAssertEqual(events.at(..<200).filter(.next).count, 0)
+            XCTAssertEqual(events.at(200...).filter(.next).count, 1)
+        }
+    }
+
 }
 #endif
 


### PR DESCRIPTION
This commit add these new features:
- comment functions in UIViewController+Rx.swift file
- we can be triggered when a UIViewController:
	- is displayed for the first time
	- has a displayed state change (showed or hidden)
	- is dismissed
	- has its parents dismissed