### PR TITLE
Removed superfluous access modifiers to silence Swift 5 warnings

### DIFF
--- a/Sources/RxViewController/NSViewController+Rx.swift
+++ b/Sources/RxViewController/NSViewController+Rx.swift
@@ -5,34 +5,34 @@ import RxCocoa
 import RxSwift
 
 public extension Reactive where Base: NSViewController {
-  public var viewDidLoad: ControlEvent<Void> {
+  var viewDidLoad: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.viewDidLoad)).map { _ in }
     return ControlEvent(events: source)
   }
 
-  public var viewWillAppear: ControlEvent<Void> {
+  var viewWillAppear: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.viewWillAppear)).map { _ in }
     return ControlEvent(events: source)
   }
-  public var viewDidAppear: ControlEvent<Void> {
+  var viewDidAppear: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.viewDidAppear)).map { _ in }
     return ControlEvent(events: source)
   }
 
-  public var viewWillDisappear: ControlEvent<Void> {
+  var viewWillDisappear: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.viewWillDisappear)).map { _ in }
     return ControlEvent(events: source)
   }
-  public var viewDidDisappear: ControlEvent<Void> {
+  var viewDidDisappear: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.viewDidDisappear)).map { _ in }
     return ControlEvent(events: source)
   }
 
-  public var viewWillLayout: ControlEvent<Void> {
+  var viewWillLayout: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.viewWillLayout)).map { _ in }
     return ControlEvent(events: source)
   }
-  public var viewDidLayout: ControlEvent<Void> {
+  var viewDidLayout: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.viewDidLayout)).map { _ in }
     return ControlEvent(events: source)
   }

--- a/Sources/RxViewController/UIViewController+Rx.swift
+++ b/Sources/RxViewController/UIViewController+Rx.swift
@@ -5,64 +5,64 @@ import RxCocoa
 import RxSwift
 
 public extension Reactive where Base: UIViewController {
-  public var viewDidLoad: ControlEvent<Void> {
+  var viewDidLoad: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.viewDidLoad)).map { _ in }
     return ControlEvent(events: source)
   }
 
-  public var viewWillAppear: ControlEvent<Bool> {
+  var viewWillAppear: ControlEvent<Bool> {
     let source = self.methodInvoked(#selector(Base.viewWillAppear)).map { $0.first as? Bool ?? false }
     return ControlEvent(events: source)
   }
-  public var viewDidAppear: ControlEvent<Bool> {
+  var viewDidAppear: ControlEvent<Bool> {
     let source = self.methodInvoked(#selector(Base.viewDidAppear)).map { $0.first as? Bool ?? false }
     return ControlEvent(events: source)
   }
 
-  public var viewWillDisappear: ControlEvent<Bool> {
+  var viewWillDisappear: ControlEvent<Bool> {
     let source = self.methodInvoked(#selector(Base.viewWillDisappear)).map { $0.first as? Bool ?? false }
     return ControlEvent(events: source)
   }
-  public var viewDidDisappear: ControlEvent<Bool> {
+  var viewDidDisappear: ControlEvent<Bool> {
     let source = self.methodInvoked(#selector(Base.viewDidDisappear)).map { $0.first as? Bool ?? false }
     return ControlEvent(events: source)
   }
 
-  public var viewWillLayoutSubviews: ControlEvent<Void> {
+  var viewWillLayoutSubviews: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.viewWillLayoutSubviews)).map { _ in }
     return ControlEvent(events: source)
   }
-  public var viewDidLayoutSubviews: ControlEvent<Void> {
+  var viewDidLayoutSubviews: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.viewDidLayoutSubviews)).map { _ in }
     return ControlEvent(events: source)
   }
 
-  public var willMoveToParentViewController: ControlEvent<UIViewController?> {
+  var willMoveToParentViewController: ControlEvent<UIViewController?> {
     let source = self.methodInvoked(#selector(Base.willMove)).map { $0.first as? UIViewController }
     return ControlEvent(events: source)
   }
-  public var didMoveToParentViewController: ControlEvent<UIViewController?> {
+  var didMoveToParentViewController: ControlEvent<UIViewController?> {
     let source = self.methodInvoked(#selector(Base.didMove)).map { $0.first as? UIViewController }
     return ControlEvent(events: source)
   }
 
-  public var didReceiveMemoryWarning: ControlEvent<Void> {
+  var didReceiveMemoryWarning: ControlEvent<Void> {
     let source = self.methodInvoked(#selector(Base.didReceiveMemoryWarning)).map { _ in }
     return ControlEvent(events: source)
   }
 
-    /// Rx observable, triggered when the ViewController appearance state changes (true if the View is being displayed, false otherwise)
-    public var isVisible: Observable<Bool> {
-        let viewDidAppearObservable = self.base.rx.viewDidAppear.map { _ in true }
-        let viewWillDisappearObservable = self.base.rx.viewWillDisappear.map { _ in false }
-        return Observable<Bool>.merge(viewDidAppearObservable, viewWillDisappearObservable)
-    }
+  /// Rx observable, triggered when the ViewController appearance state changes (true if the View is being displayed, false otherwise)
+  var isVisible: Observable<Bool> {
+      let viewDidAppearObservable = self.base.rx.viewDidAppear.map { _ in true }
+      let viewWillDisappearObservable = self.base.rx.viewWillDisappear.map { _ in false }
+      return Observable<Bool>.merge(viewDidAppearObservable, viewWillDisappearObservable)
+  }
 
-    /// Rx observable, triggered when the ViewController is being dismissed
-    public var isDismissing: ControlEvent<Bool> {
-        let source = self.sentMessage(#selector(Base.dismiss)).map { $0.first as? Bool ?? false }
-        return ControlEvent(events: source)
-    }
+  /// Rx observable, triggered when the ViewController is being dismissed
+  var isDismissing: ControlEvent<Bool> {
+      let source = self.sentMessage(#selector(Base.dismiss)).map { $0.first as? Bool ?? false }
+      return ControlEvent(events: source)
+  }
 
 }
 #endif


### PR DESCRIPTION
Eliminates warnings when building with Xcode 10.2b2